### PR TITLE
Fix disk load issue that read sectors beyond disk image size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,10 @@ KERNEL_BIN = $(KERNEL_BUILD_DIR)/kernel.bin
 # Default target
 all: $(DISK_IMG)
 
-# Build bootloader and kernel
+# Build bootloader and kernel creating a 1.44MiB floppy
 $(DISK_IMG): $(BOOTLOADER_BIN) $(KERNEL_BIN)
 	cat $(BOOTLOADER_BIN) $(KERNEL_BIN) > $(DISK_IMG)
+	truncate -s 1440K $(DISK_IMG)
 
 # Ensure bootloader is built
 $(BOOTLOADER_BIN):
@@ -45,6 +46,9 @@ $(BOOTLOADER_BIN):
 # Ensure kernel is built
 $(KERNEL_BIN):
 	$(MAKE) -C $(KERNEL_DIR) all
+
+run-bootloader: $(DISK_IMG)
+	qemu-system-i386 -fda $<
 
 # Clean build files
 clean:

--- a/bootloader/bootloader.asm
+++ b/bootloader/bootloader.asm
@@ -6,6 +6,8 @@ start:
     xor ax, ax      ; Zero out AX
     mov ds, ax      ; Set Data Segment to 0x0000
     mov es, ax      ; Set Extra Segment to 0x0000
+    mov ss, ax      ; Set SS:SP to 0x0000:0xfffe
+    mov sp, 0xfffe
 
     ; Print "AnimikhaOS is booting" to the screen
     mov si, message
@@ -28,7 +30,7 @@ delay:
     call load_kernel
 
     ; Jump to kernel
-    jmp 0x1000         ; Assuming kernel entry point is at 0x1000
+    jmp 0x0000:0x1000         ; Assuming kernel entry point is at 0x1000, Set CS to 0
 
 delay_1s:
     push cx
@@ -40,10 +42,11 @@ delay_loop:
     ret
 
 load_kernel:
-    ; Load kernel from disk to 0x1000:0000
-    mov bx, 0x1000     ; Load to address 0x1000:0000
+    ; Load kernel from disk to 0x0000:0x1000
+    mov bx, 0x0000     ; Load to address 0x0000:0x1000
     mov dh, 0          ; Track (head) number
-    mov dl, 0x80       ; Drive number (first hard drive)
+;   Use DL passed by BIOS to bootloader
+;   mov dl, 0x80       ; Drive number (first hard drive)
     mov ch, 0          ; Cylinder number
     mov cl, 2          ; Start reading from sector 2
 
@@ -51,7 +54,7 @@ load_kernel:
     mov ah, 0x02       ; BIOS read sectors
     mov al, 18         ; Number of sectors to read
     mov es, bx         ; ES:BX -> destination segment:offset
-    mov bx, 0x0000     ; Offset in segment
+    mov bx, 0x1000     ; Offset in segment
 
     int 0x13           ; BIOS disk interrupt
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -2,11 +2,12 @@
 NASM = nasm
 CXX = g++
 LD = ld
+OBJCOPY = objcopy
 
 # Flags
 NASMFLAGS = -f elf32
 CXXFLAGS = -m32 -fno-pie -fno-stack-protector -nostdlib -fno-rtti -fno-exceptions -ffreestanding -O2
-LDFLAGS = -m elf_i386 -T kernel.ld --oformat binary
+LDFLAGS = -m elf_i386 -T kernel.ld
 
 # Directories
 KERNEL_DIR = .
@@ -26,6 +27,7 @@ ALL_OBJECTS = $(ASM_OBJECTS) $(CPP_OBJECTS)
 
 # Output kernel binary
 KERNEL = $(BUILD_DIR)/kernel.bin
+KERNEL_ELF = $(BUILD_DIR)/kernel.elf
 
 # Make sure these directories exist
 NEEDED_DIRS = $(dir $(ASM_OBJECTS) $(CPP_OBJECTS))
@@ -45,9 +47,13 @@ $(BUILD_DIR)/%.o: $(KERNEL_DIR)/%.asm
 $(BUILD_DIR)/%.o: $(KERNEL_DIR)/%.cpp
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
-# Link everything together
-$(KERNEL): $(ALL_OBJECTS)
+# Link everything together to an ELF file
+$(KERNEL_ELF): $(ALL_OBJECTS)
 	$(LD) $(LDFLAGS) $(ALL_OBJECTS) -o $@
+
+# Convert kernel elf file to bin file
+$(KERNEL): $(KERNEL_ELF)
+	$(OBJCOPY) -O binary $< $@
 
 # Clean build files
 clean:

--- a/kernel/kernel.ld
+++ b/kernel/kernel.ld
@@ -1,11 +1,13 @@
 ENTRY(start)  /* Assuming 'start' is your entry point label in main.asm */
-
 SECTIONS
 {
-    . = 0x100000;    /* Kernel loads at 1MB */
+    . = 0x1000;    /* Kernel loaded at 0x1000 by bootloader */
 
     .text :
     {
+        /* .text.startup section is first so it
+           will be the first code executed */
+        *(.text.startup)
         *(.text)
     }
 

--- a/kernel/main/main.asm
+++ b/kernel/main/main.asm
@@ -1,14 +1,19 @@
-section .text
+bits 16
+section .text.startup
 global start
 
 start:
+    ; Note: we are not in 32-bit protected mode at this point
+    ; We are still in 16-bit real mode. Eventually when you
+    ; call into 32-bit C code you will have to enter 32-bit
+    ; protected mode first. This code doesn't enter 32-bit
+    ; protected mode
     cli                  ; Clear interrupts
     cld                  ; Clear direction flag
     xor ax, ax           ; Zero out AX
     mov ds, ax           ; Set DS to 0x0000
     mov es, ax           ; Set ES to 0x0000
-    mov ss, ax           ; Set SS to 0x0000
-    mov esp, 0x9FC0      ; Set stack pointer (somewhere below 0xA000)
+                         ; Real mode stack set in bootloader
 
     ; Call the memory detection function
     call detect_memory

--- a/kernel/main/main.asm
+++ b/kernel/main/main.asm
@@ -6,8 +6,7 @@ start:
     ; Note: we are not in 32-bit protected mode at this point
     ; We are still in 16-bit real mode. Eventually when you
     ; call into 32-bit C code you will have to enter 32-bit
-    ; protected mode first. This code doesn't enter 32-bit
-    ; protected mode
+    ; protected mode first.
     cli                  ; Clear interrupts
     cld                  ; Clear direction flag
     xor ax, ax           ; Zero out AX


### PR DESCRIPTION
- Modify `Makefile` to generate a 1.44MiB disk image with `truncate`. You were reading sectors beyond the end of of the disk image and caused a disk read error
- Use the boot drive number passed by BIOS in register `DL` rather than hardcoding 0x80 (first hard disk)
- inconsistent memory address for kernel so I used 0x0x0000:1000 which is physical address 0x1000. Bootloader and the `kernel.ld` now match. It appears you may not understand segment:offset addressing well enough yet 
- Added `.text.startup` input section to `linker.ld` so the linker knows what code will be placed first in the executable
- Place `start` label at beginning of `.text.startup` in `main.asm` 
- The code at label `start` is still in 16-bit real mode so use `bits 16` directive to ensure 16-bit code is generated by NASM
- Modify `Makefile` to generate `kernel.elf` file and then use OBJCOPY to convert it to `kernel.bin`. `kernel.elf` can be useful in aiding debugging

Note: Your code doesn't enter 32-bit protected mode. You will have to do that before you call into any C/C++ code.